### PR TITLE
docs(readme): fix coverage badge (remove flag)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ __:warning:NEVER MANUALLY EDIT SOURCES IN THE [`generated`] DIRECTORY! :warning:
 
 [GHA CI img]: https://github.com/zbeekman/ZstdFortranLib/workflows/CI/badge.svg "CI build status badge"
 [GH Actions CI]: https://github.com/zbeekman/ZstdFortranLib/actions "GH Actions CI"
-[Test Coverage img]: https://codecov.io/gh/zbeekman/ZstdFortranLib/branch/master/graph/badge.svg?flag=unittest_core "Codecov badge"
+[Test Coverage img]: https://codecov.io/gh/zbeekman/ZstdFortranLib/branch/master/graph/badge.svg "Codecov badge"
 [Code Coverage]: https://codecov.io/gh/zbeekman/ZstdFortranLib/branch/develop "Code Coverage"
 [Docs img]: https://readthedocs.org/projects/zstdfortranlib/badge/?version=latest "RTD badge"
 [Documentation]: https://zstdfortranlib.readthedocs.io/en/latest/?badge=latest "High level documentation"


### PR DESCRIPTION
Flag query for codecov coverage badge does not work, just show overall coverage.

# Pull request summary

Fix coverage badge in readme (flag queries don't seem to work)

## Additional information

N/A

## Pull request checklist

<!-- If you do not fill out the checklist below your pull request may be closed without comment -->

- [x] Have you followed the guidelines in our [Contributing] document?
- [x] Have you checked to ensure there aren't other open [Pull Requests] for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes?
- [x] Have you successfully tested your changes locally?

[Contributing]: ../blob/master/CONTRIBUTING.md
[Pull Requests]: ../pulls
